### PR TITLE
Change the default client facing RPC port from 18081 to 26968

### DIFF
--- a/src/CmdLineOptions.cpp
+++ b/src/CmdLineOptions.cpp
@@ -63,7 +63,7 @@ namespace xmreg
                  "path to crt file for ssl (https) functionality")
                 ("ssl-key-file", value<string>(),
                  "path to key file for ssl (https) functionality")
-                ("deamon-url,d", value<string>()->default_value("http:://127.0.0.1:18081"),
+                ("deamon-url,d", value<string>()->default_value("http:://127.0.0.1:26968"),
                  "Monero deamon url");
 
 

--- a/src/CurrentBlockchainStatus.cpp
+++ b/src/CurrentBlockchainStatus.cpp
@@ -303,7 +303,7 @@ bool   CurrentBlockchainStatus::testnet {false};
 
 string CurrentBlockchainStatus::output_file {"emission_amount.txt"};
 
-string CurrentBlockchainStatus::deamon_url {"http:://127.0.0.1:18081"};
+string CurrentBlockchainStatus::deamon_url {"http:://127.0.0.1:26968"};
 
 uint64_t  CurrentBlockchainStatus::blockchain_chunk_size {10000};
 

--- a/src/MempoolStatus.cpp
+++ b/src/MempoolStatus.cpp
@@ -284,7 +284,7 @@ MempoolStatus::is_thread_running()
 }
 
 bf::path MempoolStatus::blockchain_path {"/home/mwo/.bitmonero/lmdb"};
-string MempoolStatus::deamon_url {"http:://127.0.0.1:18081"};
+string MempoolStatus::deamon_url {"http:://127.0.0.1:26968"};
 bool   MempoolStatus::testnet {false};
 atomic<bool>       MempoolStatus::is_running {false};
 boost::thread      MempoolStatus::m_thread;

--- a/src/rpccalls.h
+++ b/src/rpccalls.h
@@ -80,7 +80,7 @@ class rpccalls
 
 public:
 
-    rpccalls(string _deamon_url = "http:://127.0.0.1:18081",
+    rpccalls(string _deamon_url = "http:://127.0.0.1:26968",
              uint64_t _timeout = 200000);
 
     bool


### PR DESCRIPTION
By changing these port numbers, we can make the setup of the blockchain explorer a lot simpler compared to before.