### PR TITLE
Fixed variable name mismatch with Electroneum source

### DIFF
--- a/src/page.h
+++ b/src/page.h
@@ -4996,7 +4996,7 @@ namespace xmreg
                     {"last_git_commit_hash", string {GIT_COMMIT_HASH}},
                     {"last_git_commit_date", string {GIT_COMMIT_DATETIME}},
                     {"git_branch_name"     , string {GIT_BRANCH_NAME}},
-                    {"monero_version_full" , string {MONERO_VERSION_FULL}},
+                    {"monero_version_full" , string {ELECTRONEUM_VERSION_FULL}},
                     {"api"                 , ONIONEXPLORER_RPC_VERSION},
                     {"blockchain_height"   , core_storage->get_current_blockchain_height()}
             };
@@ -5963,7 +5963,7 @@ namespace xmreg
                     {"last_git_commit_hash", string {GIT_COMMIT_HASH}},
                     {"last_git_commit_date", string {GIT_COMMIT_DATETIME}},
                     {"git_branch_name"     , string {GIT_BRANCH_NAME}},
-                    {"monero_version_full" , string {MONERO_VERSION_FULL}},
+                    {"monero_version_full" , string {ELECTRONEUM_VERSION_FULL}},
                     {"api"                 , std::to_string(ONIONEXPLORER_RPC_VERSION_MAJOR)
                                              + "."
                                              + std::to_string(ONIONEXPLORER_RPC_VERSION_MINOR)},


### PR DESCRIPTION
Changed from MONERO_VERSION_FULL to ELECTRONEUM_VERISON_FULL to match changes made as part of the Electroneum rebrand.